### PR TITLE
Add ChatGPT usage instructions and configure OpenAPI server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ requiere al menos `OPENAI_API_KEY` y `DATABASE_URL`.
 
 La versión completa de la API se ejecuta desde `app/main.py`. Se incluye un
 ejemplo más simple en `examples/simple_main.py` solo para pruebas locales.
+
+## Using ChatGPT
+
+1. Define tu clave de OpenAI en el archivo `.env` mediante la variable
+   `OPENAI_API_KEY`.
+2. Importa y utiliza la función `consulta_gpt` del módulo `openai_client.py` en
+   tu código.
+3. Puedes experimentar de forma local ejecutando el ejemplo
+   `examples/simple_main.py`.
+
+```python
+from openai_client import consulta_gpt
+
+respuesta = consulta_gpt("¿Cuál es la capital de Chile?")
+print(respuesta)
+```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Cuanto Cuesta API"
     PROJECT_VERSION: str = "1.0.0"
     DEBUG: bool = True
+    BASE_URL: str | None = None
     
     # Rate limiting
     RATE_LIMIT_PER_MINUTE: int = 100

--- a/app/main.py
+++ b/app/main.py
@@ -225,6 +225,9 @@ def custom_openapi():
         description=app.description,
         routes=app.routes,
     )
+
+    base_url = settings.BASE_URL or "https://cuantocuestabackend.onrender.com"
+    openapi_schema["servers"] = [{"url": base_url}]
     
     # Personalizar información adicional
     openapi_schema["info"]["x-logo"] = {


### PR DESCRIPTION
## Summary
- document how to use ChatGPT with `consulta_gpt`
- expose the application base URL in the OpenAPI `servers` list, configurable via `BASE_URL`

## Testing
- `python - <<'PY'
import warnings
warnings.filterwarnings('ignore')
from app.main import app
print(app.openapi().get('servers'))
PY`
- `pytest -q` *(fails: unsupported UUID compilation and related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688bcbaa582883208127ea5fb1ce7142