### PR TITLE
Suggest alternative brand when out of stock

### DIFF
--- a/app/api/v1/endpoints/productos.py
+++ b/app/api/v1/endpoints/productos.py
@@ -81,7 +81,15 @@ async def buscar_productos(
             limite=limite,
             skip=skip
         )
-        
+
+        # Sugerir marca alternativa cuando no hay stock disponible
+        for prod in result.get("productos", []):
+            if prod.get("tiendas_disponibles", 0) == 0:
+                alternativa = product_service.get_alternative_brand(db, UUID(prod["id"]))
+                if alternativa:
+                    prod["marca_sugerida"] = alternativa
+                    prod["explicacion"] = f"Producto sin stock disponible. Se sugiere marca {alternativa}."
+
         # Agregar tiempo de respuesta
         end_time = time.time()
         result["tiempo_respuesta_ms"] = int((end_time - start_time) * 1000)

--- a/app/schemas/price.py
+++ b/app/schemas/price.py
@@ -78,6 +78,12 @@ class PriceComparisonResponse(BaseModel):
     recomendacion: str = Field(..., description="Recomendación de compra")
     ahorro_maximo: float = Field(..., description="Máximo ahorro posible")
     filtros_aplicados: Dict[str, Any] = Field(..., description="Filtros aplicados en la búsqueda")
+    marca_sugerida: Optional[str] = Field(
+        None, description="Marca alternativa sugerida cuando no hay stock"
+    )
+    explicacion: Optional[str] = Field(
+        None, description="Explicación de la sugerencia de marca"
+    )
     
     class Config(Config):
         schema_extra = {

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -55,6 +55,12 @@ class ProductResponse(BaseModel):
     porcentaje_descuento: Optional[float] = Field(None, description="Porcentaje de descuento")
     tienda_mejor_precio: Optional[str] = Field(None, description="Tienda con mejor precio")
     tiendas_disponibles: int = Field(0, description="Número de tiendas donde está disponible")
+    marca_sugerida: Optional[str] = Field(
+        None, description="Marca alternativa sugerida cuando no hay stock"
+    )
+    explicacion: Optional[str] = Field(
+        None, description="Explicación de la sugerencia de marca"
+    )
     
     class Config(Config):
         schema_extra = {

--- a/tests/test_precios.py
+++ b/tests/test_precios.py
@@ -1,0 +1,35 @@
+"""
+Tests para endpoints de precios
+"""
+import pytest
+from fastapi.testclient import TestClient
+from tests.conftest import TestUtils
+
+
+class TestPriceEndpoints:
+    """Tests para comparación de precios"""
+
+    def test_comparar_precios_sin_sugerencia(self, client: TestClient, sample_product, sample_price):
+        """No debe sugerir marca cuando hay stock"""
+        response = client.get(f"/api/v1/precios/comparar/{sample_product.id}")
+
+        TestUtils.assert_response_success(response)
+        data = response.json()
+        assert data["precios"]
+        assert "marca_sugerida" not in data
+
+    def test_comparar_precios_con_sugerencia(
+        self,
+        client: TestClient,
+        sample_product,
+        sample_product_alt,
+        sample_price_alt,
+    ):
+        """Debe sugerir marca alternativa cuando no hay stock"""
+        response = client.get(f"/api/v1/precios/comparar/{sample_product.id}")
+
+        TestUtils.assert_response_success(response)
+        data = response.json()
+        assert data["precios"] == []
+        assert data["marca_sugerida"] == "Alternative Brand"
+        assert "Alternative Brand" in data["explicacion"]

--- a/tests/test_productos.py
+++ b/tests/test_productos.py
@@ -68,6 +68,38 @@ class TestProductsEndpoints:
         response = client.get("/api/v1/productos/buscar?q=Test&lat=-33.4489")
         
         TestUtils.assert_response_error(response, 400)
+
+    def test_buscar_productos_con_sugerencia(
+        self,
+        client: TestClient,
+        sample_product,
+        sample_product_alt,
+        sample_price_alt,
+    ):
+        """Debe sugerir marca alternativa cuando no hay stock"""
+        response = client.get(f"/api/v1/productos/buscar?q={sample_product.name}")
+
+        TestUtils.assert_response_success(response)
+        data = response.json()
+        producto = data["productos"][0]
+        assert producto["marca_sugerida"] == "Alternative Brand"
+        assert "Alternative Brand" in producto["explicacion"]
+
+    def test_buscar_productos_sin_sugerencia(
+        self,
+        client: TestClient,
+        sample_product,
+        sample_price,
+        sample_product_alt,
+        sample_price_alt,
+    ):
+        """No debe sugerir marca cuando hay stock disponible"""
+        response = client.get(f"/api/v1/productos/buscar?q={sample_product.name}")
+
+        TestUtils.assert_response_success(response)
+        data = response.json()
+        producto = data["productos"][0]
+        assert "marca_sugerida" not in producto
     
     def test_buscar_productos_invalid_price_range(self, client: TestClient):
         """Test búsqueda con rango de precios inválido"""


### PR DESCRIPTION
## Summary
- add service method to lookup alternative brand by category
- surface suggested brand in product search and price comparison APIs when no stock
- extend schemas and tests for brand suggestions

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such function: CreateSpatialIndex)*

------
https://chatgpt.com/codex/tasks/task_e_68921b5853548320945b3bb09634d042