### PR TITLE
refactor: use env database url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ requiere al menos `OPENAI_API_KEY` y `DATABASE_URL`. Si tu contraseña de base d
 datos contiene caracteres especiales (por ejemplo `!`), pon el valor entre
 comillas o codifica esos caracteres (`!` → `%21`).
 
+### Render
+
+Si despliegas la aplicación en [Render](https://render.com), debes definir la
+variable `DATABASE_URL` en tu servicio:
+
+1. En el panel de Render ve a tu servicio → **Environment**.
+2. Agrega una nueva variable con nombre `DATABASE_URL` y como valor la cadena de
+   conexión de tu base de datos PostgreSQL.
+3. Guarda los cambios y realiza el despliegue para que la aplicación use esta
+   configuración.
+
 La versión completa de la API se ejecuta desde `app/main.py`. Se incluye un
 ejemplo más simple en `examples/simple_main.py` solo para pruebas locales.
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     """Configuración de la aplicación"""
     
     # Database
-    DATABASE_URL: str = "postgresql://postgres:Leon2017@localhost:5432/DealFinder"
+    DATABASE_URL: str
     
     # Redis Cache
     REDIS_URL: str = "redis://localhost:6379/0"

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -21,12 +21,9 @@ engine = create_engine(
     echo=settings.DEBUG,
     pool_pre_ping=True,
     pool_recycle=300,
-    pool_size=10,  # Aumentado para conversation service
-    max_overflow=30,  # Aumentado para conversation service
-    connect_args={
-        "client_encoding": "utf8",
-        "application_name": "CuantoCuesta_ConversationService"
-    }
+    pool_size=2,
+    max_overflow=5,
+    connect_args={"sslmode": "require"},
 )
 
 # Configuración de sesiones


### PR DESCRIPTION
## Summary
- remove hardcoded DB credentials and use DATABASE_URL env var
- tune SQLAlchemy engine pool and require SSL connection
- document setting DATABASE_URL on Render

## Testing
- `pytest -q` *(fails: 6 failed, 18 passed, 47 warnings, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68921b5cddc08320af19bc762c84057e