### PR TITLE
feat: make openai client async

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ ejemplo más simple en `examples/simple_main.py` solo para pruebas locales.
 
 1. Define tu clave de OpenAI en el archivo `.env` mediante la variable
    `OPENAI_API_KEY`.
-2. Importa y utiliza la función `consulta_gpt` del módulo `openai_client.py` en
-   tu código.
+2. Importa y utiliza la función asíncrona `consulta_gpt` del módulo
+   `openai_client.py` en tu código.
 3. Puedes experimentar de forma local ejecutando el ejemplo
    `examples/simple_main.py`.
 
 ```python
+import asyncio
 from openai_client import consulta_gpt
 
-respuesta = consulta_gpt("¿Cuál es la capital de Chile?")
-print(respuesta)
+
+async def main():
+    respuesta = await consulta_gpt("¿Cuál es la capital de Chile?")
+    print(respuesta)
+
+
+asyncio.run(main())
 ```

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,13 +1,49 @@
-# openai_client.py
+"""Cliente asíncrono para interactuar con la API de OpenAI."""
+
+import asyncio
+import logging
 import os
-from openai import OpenAI
+from typing import Optional
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+from openai import AsyncOpenAI, AuthenticationError, OpenAIError
 
-def consulta_gpt(prompt: str) -> str:
-    response = client.chat.completions.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.7
+logger = logging.getLogger(__name__)
+
+API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")
+
+if API_KEY:
+    client = AsyncOpenAI(api_key=API_KEY)
+else:
+    logger.error(
+        "OPENAI_API_KEY no configurada. El cliente de OpenAI no fue inicializado."
     )
-    return response.choices[0].message.content.strip()
+    client = None
+
+
+async def consulta_gpt(prompt: str) -> str:
+    """Realiza una consulta al modelo GPT.
+
+    Si no hay clave de API configurada o ocurre algún error, se retorna un mensaje
+    descriptivo y se registra el incidente en el log.
+    """
+
+    if client is None:
+        return "OPENAI_API_KEY no configurada. No se pudo realizar la consulta."
+
+    try:
+        response = await client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+        return response.choices[0].message.content.strip()
+    except AuthenticationError as exc:
+        logger.error("Error de autenticación con OpenAI: %s", exc)
+        return "Error de autenticación con OpenAI."
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        logger.error("La solicitud a OpenAI excedió el tiempo de espera: %s", exc)
+        return "La solicitud a OpenAI excedió el tiempo de espera."
+    except OpenAIError as exc:
+        logger.error("Error de OpenAI: %s", exc)
+        return "Ocurrió un error al consultar el modelo."
+


### PR DESCRIPTION
## Summary
- refactor OpenAI client to use AsyncOpenAI and async function
- handle missing API key and various OpenAI exceptions with logging
- document async usage of `consulta_gpt`

## Testing
- `pytest` *(fails: sqlalchemy.exc.CompileError: (in table 'categoria'...))*

------
https://chatgpt.com/codex/tasks/task_e_68921b5b25248320bc35268e9634980d