### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DATABASE_URL=postgresql://postgres.zrturgbbehgnjnvjqgyw:LeonJuancho2017!@aws-0-us-east-2.pooler.supabase.com:6543/postgres
 ENVIRONMENT=development
 PORT=10000
+CORS_ORIGINS=https://chat.openai.com,http://localhost:3000

--- a/app/main.py
+++ b/app/main.py
@@ -99,7 +99,7 @@ app = FastAPI(
 # Configurar CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # En producción, especificar dominios exactos
+    allow_origins=settings.CORS_ORIGINS.split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow configuring CORS origins via `CORS_ORIGINS` env var
- add example domains to `.env`

## Testing
- `python - <<'PY'
from fastapi.testclient import TestClient
from app.main import app
client = TestClient(app)
resp = client.options('/health', headers={'Origin': 'https://chat.openai.com', 'Access-Control-Request-Method': 'GET'})
print('status', resp.status_code)
print('allow_origin', resp.headers.get('access-control-allow-origin'))
print('allow_methods', resp.headers.get('access-control-allow-methods'))
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: Compiler can't render element of type UUID)*

------
https://chatgpt.com/codex/tasks/task_e_68921b5f3f2c8320a35ef325eb3ef15c