### PR TITLE
feat: add redis rate limiting

### DIFF
--- a/app/api/v1/endpoints/precios.py
+++ b/app/api/v1/endpoints/precios.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 import time
 
+from fastapi_limiter import limiter
+from app.core.config import settings
 from app.core.database import get_db
 from app.services.price_service import price_service
 from app.schemas.price import (
@@ -28,6 +30,10 @@ router = APIRouter()
         400: {"model": ErrorResponse, "description": "Parámetros inválidos"},
         500: {"model": ErrorResponse, "description": "Error interno del servidor"}
     }
+)
+@limiter.limit(
+    f"{settings.RATE_LIMIT_PER_MINUTE}/minute",
+    error_message="Demasiadas solicitudes, intenta nuevamente más tarde."
 )
 async def comparar_precios(
     producto_id: UUID = Path(..., description="ID único del producto"),

--- a/app/api/v1/endpoints/productos.py
+++ b/app/api/v1/endpoints/productos.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 import time
 
+from fastapi_limiter import limiter
+from app.core.config import settings
 from app.core.database import get_db
 from app.services.product_service import product_service
 from app.schemas.product import (
@@ -28,6 +30,10 @@ router = APIRouter()
         400: {"model": ErrorResponse, "description": "Parámetros de búsqueda inválidos"},
         500: {"model": ErrorResponse, "description": "Error interno del servidor"}
     }
+)
+@limiter.limit(
+    f"{settings.RATE_LIMIT_PER_MINUTE}/minute",
+    error_message="Demasiadas solicitudes, intenta nuevamente más tarde."
 )
 async def buscar_productos(
     q: str = Query(..., min_length=1, max_length=100, description="Término de búsqueda"),

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,8 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
 import uvicorn
+from redis import asyncio as aioredis
+from fastapi_limiter import FastAPILimiter
 
 from app.core.config import settings
 from app.core.database import check_database_connection, create_database
@@ -31,15 +33,21 @@ start_time = time.time()
 async def lifespan(app: FastAPI):
 
     logger.info("Iniciando aplicación Cuanto Cuesta...")
-    
+
+    redis = aioredis.from_url(
+        settings.REDIS_URL, encoding="utf-8", decode_responses=True
+    )
+    await FastAPILimiter.init(redis)
+
     # Verificar conexión a base de datos (desactivado temporalmente)
     # if not await verify_database_connection():
     #     logger.error("No se pudo conectar a la base de datos")
     #     raise Exception("Error de conexión a base de datos")
-    
+
     yield
-    
+
     # Shutdown
+    await redis.close()
     logger.info("Cerrando aplicación...")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ passlib[bcrypt]==1.7.4
 # Cache y Redis
 redis==5.0.1
 hiredis==2.2.3
+fastapi-limiter==0.1.5
 
 # Validación y configuración
 pydantic==2.5.0


### PR DESCRIPTION
## Summary
- add FastAPI limiter backed by Redis
- protect product search and price comparison endpoints with per-minute limits
- document fastapi-limiter dependency

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi_limiter')*

------
https://chatgpt.com/codex/tasks/task_e_68921b5deed48320902be7f070e650d4