### PR TITLE
Implement strict input validation and sanitization

### DIFF
--- a/app/api/v1/endpoints/productos.py
+++ b/app/api/v1/endpoints/productos.py
@@ -30,7 +30,9 @@ router = APIRouter()
     }
 )
 async def buscar_productos(
-    q: str = Query(..., min_length=1, max_length=100, description="Término de búsqueda"),
+    q: str = Query(
+        ..., min_length=1, max_length=100, pattern=r"^[\w\s-]+$", description="Término de búsqueda"
+    ),
     categoria_id: Optional[UUID] = Query(None, description="ID de categoría para filtrar"),
     precio_min: Optional[float] = Query(None, ge=0, description="Precio mínimo"),
     precio_max: Optional[float] = Query(None, ge=0, description="Precio máximo"),

--- a/app/api/v1/endpoints/tiendas.py
+++ b/app/api/v1/endpoints/tiendas.py
@@ -30,7 +30,9 @@ router = APIRouter()
     }
 )
 async def buscar_tiendas_por_comuna(
-    termino: str = Query(..., min_length=1, max_length=100, description="Término de búsqueda (comuna)"),
+    termino: str = Query(
+        ..., min_length=1, max_length=100, pattern=r"^[\w\s-]+$", description="Término de búsqueda (comuna)"
+    ),
     limite: int = Query(50, ge=1, le=100, description="Número máximo de resultados"),
     db: Session = Depends(get_db)
 ):

--- a/app/repositories/product_repository.py
+++ b/app/repositories/product_repository.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import select
 from app.models.product import Product
 from app.models.category import Category
 from app.repositories.base_repository import BaseRepository
+from app.utils.sanitizer import sanitize_text
 
 
 class ProductRepository(BaseRepository[Product, dict, dict]):
@@ -29,6 +30,9 @@ class ProductRepository(BaseRepository[Product, dict, dict]):
         """
         Búsqueda inteligente de productos usando texto completo y similitud
         """
+        search_term = sanitize_text(search_term)
+        if not search_term:
+            raise ValueError("search_term")
         query = db.query(Product).join(Category)
         
         # Filtrar solo productos activos
@@ -110,6 +114,9 @@ class ProductRepository(BaseRepository[Product, dict, dict]):
         limit: int = 100
     ) -> List[Product]:
         """Obtener productos por marca"""
+        brand = sanitize_text(brand)
+        if not brand:
+            raise ValueError("brand")
         return db.query(Product).filter(
             Product.brand.ilike(f'%{brand}%'),
             Product.is_active == True
@@ -158,6 +165,9 @@ class ProductRepository(BaseRepository[Product, dict, dict]):
         """
         Búsqueda por similitud con scoring
         """
+        search_term = sanitize_text(search_term)
+        if not search_term:
+            raise ValueError("search_term")
         query = text("""
             SELECT 
                 p.id,

--- a/app/repositories/store_repository.py
+++ b/app/repositories/store_repository.py
@@ -10,6 +10,7 @@ from geoalchemy2.functions import ST_DWithin, ST_Distance, ST_GeogFromText
 from app.models.store import Store
 from app.models.supermarket import Supermarket
 from app.repositories.base_repository import BaseRepository
+from app.utils.sanitizer import sanitize_text
 
 
 class StoreRepository(BaseRepository[Store, dict, dict]):
@@ -28,6 +29,9 @@ class StoreRepository(BaseRepository[Store, dict, dict]):
         Búsqueda inteligente de tiendas por comuna con manejo de caracteres especiales
         Encuentra "Ñuñoa" con cualquier variación: "Nunoa", "nunoa", "NUNOA"
         """
+        search_term = sanitize_text(search_term)
+        if not search_term:
+            raise ValueError("search_term")
         query = text("""
             SELECT 
                 s.id,

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -2,7 +2,7 @@
 Schemas para productos con nomenclatura en español
 """
 from typing import Optional, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 from uuid import UUID
 
 from app.schemas.common import CategoryInfo, PriceInfo, Config
@@ -10,7 +10,9 @@ from app.schemas.common import CategoryInfo, PriceInfo, Config
 
 class ProductSearchRequest(BaseModel):
     """Request para búsqueda de productos"""
-    q: str = Field(..., min_length=1, max_length=100, description="Término de búsqueda")
+    q: StrictStr = Field(
+        ..., min_length=1, max_length=100, pattern=r"^[\w\s-]+$", description="Término de búsqueda"
+    )
     categoria_id: Optional[UUID] = Field(None, description="ID de categoría para filtrar")
     precio_min: Optional[float] = Field(None, ge=0, description="Precio mínimo")
     precio_max: Optional[float] = Field(None, ge=0, description="Precio máximo")
@@ -147,7 +149,9 @@ class ProductDiscountsResponse(BaseModel):
 
 class ProductBarcodeRequest(BaseModel):
     """Request para búsqueda por código de barras"""
-    codigo_barras: str = Field(..., min_length=8, max_length=20, description="Código de barras del producto")
+    codigo_barras: StrictStr = Field(
+        ..., min_length=8, max_length=20, pattern=r"^[0-9]+$", description="Código de barras del producto"
+    )
     
     class Config(Config):
         schema_extra = {

--- a/app/schemas/store.py
+++ b/app/schemas/store.py
@@ -2,7 +2,7 @@
 Schemas para tiendas con nomenclatura en español
 """
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 from uuid import UUID
 
 from app.schemas.common import CoordinatesResponse, SupermarketInfo, Config
@@ -10,7 +10,9 @@ from app.schemas.common import CoordinatesResponse, SupermarketInfo, Config
 
 class StoreSearchRequest(BaseModel):
     """Request para búsqueda de tiendas"""
-    termino: str = Field(..., min_length=1, max_length=100, description="Término de búsqueda (comuna, nombre)")
+    termino: StrictStr = Field(
+        ..., min_length=1, max_length=100, pattern=r"^[\w\s-]+$", description="Término de búsqueda (comuna, nombre)"
+    )
     limite: int = Field(50, ge=1, le=100, description="Número máximo de resultados")
     
     class Config(Config):

--- a/app/utils/sanitizer.py
+++ b/app/utils/sanitizer.py
@@ -1,0 +1,11 @@
+import re
+from html import escape
+
+SAFE_PATTERN = re.compile(r'[^\w\s-]', re.UNICODE)
+
+def sanitize_text(value: str) -> str:
+    """Remove potentially dangerous characters and escape HTML."""
+    if value is None:
+        return ""
+    sanitized = SAFE_PATTERN.sub('', value)
+    return escape(sanitized.strip())

--- a/routers/gpt_router.py
+++ b/routers/gpt_router.py
@@ -1,22 +1,38 @@
 # backend/routers/gpt_router.py
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, constr, StrictFloat
 from typing import List, Optional
+
+from app.utils.sanitizer import sanitize_text
 
 router = APIRouter(prefix="/api", tags=["gpt"] )
 
+def _sanitize_and_validate(value: str) -> str:
+    sanitized = sanitize_text(value)
+    if not sanitized:
+        raise HTTPException(status_code=422, detail="Invalid input")
+    return sanitized
+
+
 class SearchRequest(BaseModel):
-    query: str
-    category: Optional[str] = None
+    query: constr(strict=True, min_length=1, max_length=100, pattern=r"^[\w\s-]+$")
+    category: Optional[constr(strict=True, max_length=50, pattern=r"^[\w\s-]+$")] = None
+
+class Location(BaseModel):
+    lat: StrictFloat = Field(..., ge=-90, le=90)
+    lon: StrictFloat = Field(..., ge=-180, le=180)
+
 
 class OptimizeRequest(BaseModel):
-    products: List[str]
-    location: Optional[dict] = None
+    products: List[constr(strict=True, min_length=1, max_length=100, pattern=r"^[\w\s-]+$")]
+    location: Optional[Location] = None
 
 @router.get("/products/search")
 async def search_products(query: str, category: Optional[str] = None):
     """Endpoint específico para que GPT busque productos"""
     try:
+        query = _sanitize_and_validate(query)
+        category = _sanitize_and_validate(category) if category else None
         # Tu lógica de búsqueda aquí
         products = await search_products_in_db(query, category)
         
@@ -32,8 +48,9 @@ async def search_products(query: str, category: Optional[str] = None):
 async def optimize_shopping_list(request: OptimizeRequest):
     """Endpoint para optimizar lista de compras"""
     try:
+        sanitized_products = [_sanitize_and_validate(p) for p in request.products]
         # Tu lógica de optimización aquí
-        optimization = await optimize_purchases(request.products, request.location)
+        optimization = await optimize_purchases(sanitized_products, request.location)
         
         return {
             "success": True,


### PR DESCRIPTION
## Summary
- enforce strict types with length and pattern constraints on search and optimization schemas
- sanitize user-provided strings before building DB queries
- surface 422 errors for invalid inputs and add reusable sanitizer helper

## Testing
- `pytest -q` *(fails: Compiler <sqlalchemy.dialects.sqlite.base.SQLiteTypeCompiler object at 0x7f0b40dd6b50> can't render element of type UUID)*

------
https://chatgpt.com/codex/tasks/task_e_68921b628fd883209ab1aabc2fbdc97e