### PR TITLE
feat: add optional rate limiter

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,11 @@ from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 
 from redis import asyncio as aioredis
-from fastapi_limiter import FastAPILimiter
+
+try:
+    from fastapi_limiter import FastAPILimiter
+except ImportError:
+    FastAPILimiter = None
 
 from app.core.config import settings
 from app.api.v1.api import api_router
@@ -65,7 +69,8 @@ ERROR_MESSAGES = {
 async def lifespan(app: FastAPI):
     logger.info("Iniciando aplicación Cuanto Cuesta...")
     redis = aioredis.from_url(settings.REDIS_URL, encoding="utf-8", decode_responses=True)
-    await FastAPILimiter.init(redis)
+    if FastAPILimiter:
+        await FastAPILimiter.init(redis)
     yield
     await redis.close()
     logger.info("Cerrando aplicación...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ passlib[bcrypt]==1.7.4
 # Cache y Redis
 redis==5.0.1
 hiredis==2.2.3
+fastapi-limiter==0.1.6
 
 rq==1.15.1
 


### PR DESCRIPTION
## Summary
- add fastapi-limiter dependency
- guard fastapi-limiter initialization in main app

## Testing
- `flake8 app/main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi_limiter')*


------
https://chatgpt.com/codex/tasks/task_e_6893813f4244832081f30f8f30e64054