### PR TITLE
Incorporate user dietary context into GPT product search

### DIFF
--- a/app/services/conversation_service.py
+++ b/app/services/conversation_service.py
@@ -605,6 +605,16 @@ class ConversationService:
                 "weight": 0.20,
                 "stability_threshold": 0.75,
                 "decay_rate": 0.03
+            },
+            "allergies": {
+                "weight": 0.15,
+                "stability_threshold": 0.9,
+                "decay_rate": 0.01
+            },
+            "dietary_restrictions": {
+                "weight": 0.15,
+                "stability_threshold": 0.9,
+                "decay_rate": 0.01
             }
         }
         
@@ -1505,20 +1515,26 @@ class ConversationService:
     def _extract_preference_profile(self, anchors: Dict[str, ContextualAnchor]) -> Dict[str, Any]:
         """Extrae perfil de preferencias del usuario"""
         pref_anchor = anchors.get("preferencias_precio")
-        
-        if pref_anchor and pref_anchor.current_value and pref_anchor.confidence > 0.3:
-            prefs = pref_anchor.current_value
-            return {
-                "optimization_priority": prefs.get("prioridad", "equilibrio"),
-                "satisfaction_level": prefs.get("satisfaccion_promedio", 3.0),
-                "confidence": pref_anchor.confidence
-            }
-        
-        return {
+        allergy_anchor = anchors.get("allergies")
+        dietary_anchor = anchors.get("dietary_restrictions")
+
+        prefs = {
             "optimization_priority": "equilibrio",
             "satisfaction_level": 3.0,
-            "confidence": 0.0
+            "allergies": allergy_anchor.current_value if allergy_anchor and allergy_anchor.current_value else [],
+            "dietary_restrictions": dietary_anchor.current_value if dietary_anchor and dietary_anchor.current_value else [],
+            "confidence": 0.0,
         }
+
+        if pref_anchor and pref_anchor.current_value and pref_anchor.confidence > 0.3:
+            pref_values = pref_anchor.current_value
+            prefs.update({
+                "optimization_priority": pref_values.get("prioridad", "equilibrio"),
+                "satisfaction_level": pref_values.get("satisfaccion_promedio", 3.0),
+                "confidence": pref_anchor.confidence,
+            })
+
+        return prefs
     
     def _extract_behavioral_patterns(self, anchors: Dict[str, ContextualAnchor]) -> Dict[str, Any]:
         """Extrae patrones de comportamiento del usuario"""

--- a/tests/test_gpt_router.py
+++ b/tests/test_gpt_router.py
@@ -28,3 +28,37 @@ async def test_search_products_in_db(monkeypatch):
 
     results = await gpt_router.search_products_in_db("Item")
     assert results[0]["nombre"] == "Item"
+
+
+@pytest.mark.asyncio
+async def test_search_products_includes_allergy_context(monkeypatch):
+    """Ensures allergy context is passed to GPT prompt."""
+
+    async def fake_search_products_in_db(query, category=None):
+        return []
+
+    captured = {}
+
+    async def fake_consulta_gpt(prompt):
+        captured["prompt"] = prompt
+        return "[]"
+
+    class DummyConversationService:
+        async def get_user_context_summary(self, user_id):
+            return {
+                "user_id": user_id,
+                "context_summary": {
+                    "preference_profile": {
+                        "allergies": ["peanut"],
+                        "dietary_restrictions": []
+                    }
+                },
+                "profile_exists": True
+            }
+
+    monkeypatch.setattr(gpt_router, "search_products_in_db", fake_search_products_in_db)
+    monkeypatch.setattr(gpt_router, "consulta_gpt", fake_consulta_gpt)
+    monkeypatch.setattr(gpt_router, "ConversationService", lambda: DummyConversationService())
+
+    await gpt_router.search_products(query="pan", user_id="user123", token="")
+    assert "peanut" in captured["prompt"]


### PR DESCRIPTION
## Summary
- track allergies and dietary restrictions in conversation service user profiles
- include user context when searching products with GPT
- test that GPT prompt receives allergy information from user context

## Testing
- `pytest -q` *(fails: AssertionError in tests/unit/test_openai_client.py::test_consulta_gpt, coverage 52.78% < 80)*
- `pytest tests/test_gpt_router.py -q` *(fails: coverage 42.31% < 80)*


------
https://chatgpt.com/codex/tasks/task_e_6894d835a6488320a6cd9506a8dc9336