### PR TITLE
feat: integrate GPT fallback into optimization

### DIFF
--- a/routers/gpt_router.py
+++ b/routers/gpt_router.py
@@ -76,7 +76,8 @@ async def optimize_shopping_list(
     """Endpoint para optimizar lista de compras (requiere token)."""
     try:
         sanitized_products = [_sanitize_and_validate(p) for p in request.products]
-        optimization = await optimize_purchases(sanitized_products, request.location)
+        product_data = await fetch_products_with_fallback(sanitized_products)
+        optimization = await optimize_purchases(product_data, request.location)
         return {
             "success": True,
             "data": optimization,
@@ -136,7 +137,31 @@ async def search_products_with_gpt(query: str, category: Optional[str] = None) -
     return []
 
 
-async def optimize_purchases(products: List[str], location: Optional[dict] = None):
+async def fetch_products_with_fallback(products: List[str]) -> List[dict]:
+    """Obtiene información estructurada de productos manteniendo su orden.
+
+    Para cada producto se busca primero en la base de datos y, si no se
+    encuentra, se consulta a GPT. Siempre se retorna un elemento por cada
+    producto solicitado para mantener el orden original de la lista.
+    """
+
+    results: List[dict] = []
+    for product in products:
+        db_results = await search_products_in_db(product)
+        if db_results:
+            results.append(db_results[0])
+            continue
+
+        gpt_results = await search_products_with_gpt(product)
+        if gpt_results:
+            results.append(gpt_results[0])
+        else:
+            # Mantener el lugar con datos mínimos si no hay resultados
+            results.append({"nombre": product})
+    return results
+
+
+async def optimize_purchases(products: List[dict], location: Optional[dict] = None):
     """Optimize a shopping list using the optimization service."""
     try:
         from app.services.optimization_service import OptimizationService

--- a/tests/test_openai_client_async.py
+++ b/tests/test_openai_client_async.py
@@ -1,0 +1,70 @@
+import types
+import pytest
+import asyncio
+
+import openai_client
+
+
+@pytest.mark.asyncio
+async def test_consulta_gpt_success(monkeypatch):
+    class DummyChoice:
+        def __init__(self, content: str):
+            self.message = types.SimpleNamespace(content=content)
+
+    class DummyResponse:
+        choices = [DummyChoice("Hola Mundo ")]
+
+    async def fake_create(**kwargs):
+        return DummyResponse()
+
+    dummy_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
+    )
+
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+
+    result = await openai_client.consulta_gpt("Hola?")
+    assert result == "Hola Mundo"
+
+
+@pytest.mark.asyncio
+async def test_consulta_gpt_no_client(monkeypatch):
+    monkeypatch.setattr(openai_client, "client", None)
+    result = await openai_client.consulta_gpt("Hola?")
+    assert "OPENAI_API_KEY" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (
+            type("DummyAuthError", (openai_client.AuthenticationError,), {"__init__": lambda self: Exception.__init__(self, "auth")})(),
+            "Error de autenticación con OpenAI.",
+        ),
+        (
+            asyncio.TimeoutError(),
+            "La solicitud a OpenAI excedió el tiempo de espera.",
+        ),
+        (
+            type("DummyOpenAIError", (openai_client.OpenAIError,), {"__init__": lambda self: Exception.__init__(self, "boom")})(),
+            "Ocurrió un error al consultar el modelo.",
+        ),
+    ],
+)
+async def test_consulta_gpt_errors(monkeypatch, exc, expected):
+    async def fake_create(**kwargs):
+        raise exc
+
+    dummy_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
+    )
+
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+
+    result = await openai_client.consulta_gpt("Hola?")
+    assert result == expected


### PR DESCRIPTION
## Summary
- fetch product details from DB or GPT while preserving list order
- pass structured product data into purchase optimization
- add tests for GPT fallback and OpenAI client coverage

## Testing
- `pytest tests/test_openai_client_async.py tests/unit/test_brand_substitution.py tests/unit/test_ocr_service.py tests/test_gpt_router.py::test_search_products_in_db tests/test_gpt_router.py::test_optimize_shopping_list_fetches_gpt_when_db_empty -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d8365c048320935147bf024332ca