### PR TITLE
Use async Redis client with early validation

### DIFF
--- a/app/api/v1/routers/health.py
+++ b/app/api/v1/routers/health.py
@@ -21,9 +21,7 @@ async def check_redis(timeout: float = 1.0) -> bool:
     if not cache.redis_client:
         return False
     try:
-        return await asyncio.wait_for(
-            asyncio.to_thread(cache.redis_client.ping), timeout
-        )
+        return await asyncio.wait_for(cache.redis_client.ping(), timeout)
     except Exception:
         return False
 

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -1,9 +1,8 @@
-"""
-Configuración de cache Redis para Cuanto Cuesta
-"""
+"""Configuración de cache Redis para Cuanto Cuesta"""
 import json
-from typing import Any, Optional, Union
-import redis
+from typing import Any, Optional
+
+from redis import asyncio as aioredis
 import structlog
 from redis.exceptions import RedisError
 
@@ -13,118 +12,126 @@ logger = structlog.get_logger(__name__)
 
 
 class RedisCache:
-    """Cliente Redis para cache"""
-    
+    """Cliente Redis asíncrono para cache"""
+
     def __init__(self):
-        self.redis_client = None
-        self._connect()
-    
-    def _connect(self):
+        self.redis_client: aioredis.Redis | None = None
+
+    async def _connect(self) -> None:
         """Conectar a Redis"""
         try:
-            self.redis_client = redis.from_url(
+            self.redis_client = aioredis.from_url(
                 settings.REDIS_URL,
                 encoding="utf-8",
                 decode_responses=True,
                 socket_connect_timeout=5,
                 socket_timeout=5,
-                retry_on_timeout=True
+                retry_on_timeout=True,
             )
-            # Probar conexión
-            self.redis_client.ping()
+            await self.redis_client.ping()
             logger.info("Conexión a Redis exitosa")
         except RedisError:
             logger.exception("Error conectando a Redis")
             self.redis_client = None
-    
-    def get(self, key: str) -> Optional[Any]:
+
+    async def get(self, key: str) -> Optional[Any]:
         """Obtener valor del cache"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return None
-        
+
         try:
-            value = self.redis_client.get(key)
+            value = await self.redis_client.get(key)
             if value:
                 return json.loads(value)
             return None
         except (RedisError, json.JSONDecodeError):
             logger.exception("Error obteniendo del cache", key=key)
             return None
-    
-    def set(
-        self, 
-        key: str, 
-        value: Any, 
-        ttl: Optional[int] = None
-    ) -> bool:
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> bool:
         """Establecer valor en el cache"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return False
-        
+
         try:
             serialized_value = json.dumps(value, default=str)
             if ttl:
-                return self.redis_client.setex(key, ttl, serialized_value)
+                await self.redis_client.setex(key, ttl, serialized_value)
             else:
-                return self.redis_client.set(key, serialized_value)
-        except (RedisError, json.JSONEncodeError):
+                await self.redis_client.set(key, serialized_value)
+            return True
+        except (RedisError, json.JSONDecodeError):
             logger.exception("Error estableciendo en cache", key=key)
             return False
-    
-    def delete(self, key: str) -> bool:
+
+    async def delete(self, key: str) -> bool:
         """Eliminar valor del cache"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return False
-        
+
         try:
-            return bool(self.redis_client.delete(key))
+            return bool(await self.redis_client.delete(key))
         except RedisError:
             logger.exception("Error eliminando del cache", key=key)
             return False
-    
-    def delete_pattern(self, pattern: str) -> int:
+
+    async def delete_pattern(self, pattern: str) -> int:
         """Eliminar claves que coincidan con el patrón"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return 0
-        
+
         try:
-            keys = self.redis_client.keys(pattern)
+            keys = await self.redis_client.keys(pattern)
             if keys:
-                return self.redis_client.delete(*keys)
+                return await self.redis_client.delete(*keys)
             return 0
         except RedisError:
             logger.exception("Error eliminando patrón", pattern=pattern)
             return 0
-    
-    def exists(self, key: str) -> bool:
+
+    async def exists(self, key: str) -> bool:
         """Verificar si existe una clave"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return False
-        
+
         try:
-            return bool(self.redis_client.exists(key))
+            return bool(await self.redis_client.exists(key))
         except RedisError:
             logger.exception("Error verificando existencia", key=key)
             return False
-    
-    def increment(self, key: str, amount: int = 1) -> Optional[int]:
+
+    async def increment(self, key: str, amount: int = 1) -> Optional[int]:
         """Incrementar valor numérico"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return None
-        
+
         try:
-            return self.redis_client.incrby(key, amount)
+            return await self.redis_client.incrby(key, amount)
         except RedisError:
             logger.exception("Error incrementando", key=key)
             return None
-    
-    def expire(self, key: str, ttl: int) -> bool:
+
+    async def expire(self, key: str, ttl: int) -> bool:
         """Establecer TTL para una clave"""
         if not self.redis_client:
+            await self._connect()
+        if not self.redis_client:
             return False
-        
+
         try:
-            return bool(self.redis_client.expire(key, ttl))
+            return bool(await self.redis_client.expire(key, ttl))
         except RedisError:
             logger.exception("Error estableciendo TTL", key=key)
             return False

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,58 +2,64 @@
 Configuración principal de la aplicación Cuanto Cuesta
 """
 from functools import lru_cache
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Configuración de la aplicación"""
-    
+
     # Database
     DATABASE_URL: str
-    
+
     # Redis Cache
-    REDIS_URL: str = "redis://localhost:6379/0"
-    
+    REDIS_URL: str | None = None
+
     # JWT
     JWT_SECRET_KEY: str = "leon2017"
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
-    
+
     # API Configuration
     API_V1_STR: str = "/api/v1"
     PROJECT_NAME: str = "Cuanto Cuesta API"
     PROJECT_VERSION: str = "1.0.0"
-    DEBUG: bool = True
+    DEBUG: bool = False
     BASE_URL: str | None = None
-    
+
     # Rate limiting
     RATE_LIMIT_PER_MINUTE: int = 100
     API_RATE_LIMIT_PER_MINUTE: int = 1000
-    
+
     # Chile Configuration
     DEFAULT_TIMEZONE: str = "America/Santiago"
     DEFAULT_CURRENCY: str = "CLP"
     DEFAULT_COUNTRY_CODE: str = "CL"
     DEFAULT_LOCALE: str = "es_CL.UTF-8"
-    
+
     # Cache TTL (seconds)
     CACHE_TTL_PRODUCTS: int = 3600
     CACHE_TTL_PRICES: int = 1800
     CACHE_TTL_STORES: int = 7200
-    
+
     # Logging
     LOG_LEVEL: str = "INFO"
     LOG_FORMAT: str = "json"
     LOG_FILE: str = "logs/app.log"
-    
+
     # CORS
     CORS_ORIGINS: str = "*"
-    
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
-        extra = "ignore"  # Ignorar campos extra del .env
+    ALLOWED_HOSTS: list[str] = ["*"]
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    def model_post_init(self, __context):  # type: ignore[override]
+        if not self.REDIS_URL and self.DEBUG:
+            self.REDIS_URL = "redis://localhost:6379/0"
 
 
 @lru_cache()

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -34,7 +34,7 @@ class LocationParams(BaseModel):
     lon: float = Field(..., ge=-180, le=180, description="Longitud")
     
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "lat": -33.4489,
                 "lon": -70.6693
@@ -147,7 +147,7 @@ class Config:
     """Configuración base para schemas"""
     use_enum_values = True
     validate_assignment = True
-    allow_population_by_field_name = True
+    populate_by_name = True
     json_encoders = {
         datetime: lambda v: v.isoformat(),
         Decimal: lambda v: float(v),

--- a/app/schemas/conversation.py
+++ b/app/schemas/conversation.py
@@ -45,7 +45,7 @@ class ConversationRequest(BaseModel):
         return v
     
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "user_id": "temp_user_abc123",
                 "interaction_data": {
@@ -85,7 +85,7 @@ class UserProfileRequest(BaseModel):
     )
     
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "user_id": "temp_user_abc123",
                 "profile_data": {

--- a/app/schemas/price.py
+++ b/app/schemas/price.py
@@ -21,7 +21,7 @@ class PriceComparisonRequest(BaseModel):
     incluir_mayoristas: bool = Field(False, description="Incluir supermercados mayoristas")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "producto_id": "123e4567-e89b-12d3-a456-426614174000",
                 "lat": -33.4489,
@@ -53,7 +53,7 @@ class PriceDetailResponse(BaseModel):
     tiempo_estimado_min: Optional[int] = Field(None, description="Tiempo estimado en minutos")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "tienda_id": "123e4567-e89b-12d3-a456-426614174000",
                 "supermercado": "Jumbo",
@@ -86,7 +86,7 @@ class PriceComparisonResponse(BaseModel):
     )
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "producto": {
                     "id": "123e4567-e89b-12d3-a456-426614174000",
@@ -117,7 +117,7 @@ class BestDealsRequest(BaseModel):
     limite: int = Field(50, ge=1, le=100, description="Número máximo de ofertas")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "min_descuento": 25.0,
                 "lat": -33.4489,
@@ -163,7 +163,7 @@ class PriceHistoryRequest(BaseModel):
     dias: int = Field(30, ge=1, le=365, description="Número de días de historial")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "producto_id": "123e4567-e89b-12d3-a456-426614174000",
                 "tienda_id": "456e7890-e89b-12d3-a456-426614174000",
@@ -221,7 +221,7 @@ class PriceAlertRequest(BaseModel):
     activa: bool = Field(True, description="Si la alerta está activa")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "producto_id": "123e4567-e89b-12d3-a456-426614174000",
                 "precio_objetivo": 800,

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -23,7 +23,7 @@ class ProductSearchRequest(BaseModel):
     skip: int = Field(0, ge=0, description="Número de resultados a omitir")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "q": "pan integral",
                 "categoria_id": None,
@@ -65,7 +65,7 @@ class ProductResponse(BaseModel):
     )
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": "123e4567-e89b-12d3-a456-426614174000",
                 "nombre": "Pan Integral",
@@ -112,7 +112,7 @@ class ProductSearchResponse(BaseModel):
     tiempo_respuesta_ms: Optional[int] = Field(None, description="Tiempo de respuesta en milisegundos")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "productos": [
                     {
@@ -160,7 +160,7 @@ class ProductBarcodeRequest(BaseModel):
     )
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "codigo_barras": "7802900123456"
             }

--- a/app/schemas/store.py
+++ b/app/schemas/store.py
@@ -16,7 +16,7 @@ class StoreSearchRequest(BaseModel):
     limite: int = Field(50, ge=1, le=100, description="Número máximo de resultados")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "termino": "Ñuñoa",
                 "limite": 20
@@ -35,7 +35,7 @@ class NearbyStoresRequest(BaseModel):
     limite: int = Field(50, ge=1, le=100, description="Número máximo de resultados")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "lat": -33.4489,
                 "lon": -70.6693,
@@ -69,7 +69,7 @@ class StoreResponse(BaseModel):
     puntuacion_similitud: Optional[float] = Field(None, description="Puntuación de similitud en búsqueda")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": "123e4567-e89b-12d3-a456-426614174000",
                 "nombre": "Jumbo Ñuñoa",
@@ -121,7 +121,7 @@ class StoreSearchResponse(BaseModel):
     tiempo_respuesta_ms: Optional[int] = Field(None, description="Tiempo de respuesta en milisegundos")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "tiendas": [
                     {
@@ -147,7 +147,7 @@ class NearbyStoresResponse(BaseModel):
     filtros_aplicados: Dict[str, Any] = Field(..., description="Filtros aplicados")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "tiendas": [
                     {
@@ -174,7 +174,7 @@ class StoreServicesRequest(BaseModel):
     limite: int = Field(50, ge=1, le=100, description="Número máximo de resultados")
     
     class Config(Config):
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "servicios": ["farmacia", "panaderia"],
                 "lat": -33.4489,

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import FastAPI
+from unittest.mock import AsyncMock, MagicMock
+
+import app.main as app_main
+from app.core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_startup_fails_on_localhost_in_production(monkeypatch):
+    monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "REDIS_URL", "redis://localhost:6379/0")
+    with pytest.raises(RuntimeError):
+        async with app_main.lifespan(FastAPI()):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_limiter_initialized_with_client(monkeypatch):
+    class DummyRedis:
+        async def ping(self):
+            return True
+
+        async def close(self):
+            pass
+
+    redis_instance = DummyRedis()
+
+    def dummy_from_url(url, *args, **kwargs):
+        return redis_instance
+
+    limiter = MagicMock()
+    limiter.init = AsyncMock()
+
+    monkeypatch.setattr(app_main, "FastAPILimiter", limiter)
+    monkeypatch.setattr(app_main.aioredis, "from_url", dummy_from_url)
+    monkeypatch.setattr(settings, "REDIS_URL", "redis://example:6379/0")
+
+    async with app_main.lifespan(app_main.app):
+        pass
+
+    limiter.init.assert_awaited_once_with(redis_instance)


### PR DESCRIPTION
## Summary
- remove implicit localhost Redis defaults and add ALLOWED_HOSTS setting
- unify Redis usage through redis.asyncio with async cache, health check, and task queue stub
- validate REDIS_URL at startup, ping Redis, and initialize rate limiter with shared client
- migrate Pydantic schemas to `json_schema_extra` and `populate_by_name`

## Testing
- `pytest` *(fails: coverage < 80% and an OpenAI client test)*


------
https://chatgpt.com/codex/tasks/task_e_6898194b35088320b3aa9b10f26fb9d8