### PR TITLE
Add REDIS_URL environment variable to Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,12 @@ services:
     plan: free
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: cuantocuesta-redis
+          property: connectionString
     healthCheckPath: /health
     healthCheckTimeoutSeconds: 2
     alerts:


### PR DESCRIPTION
## Summary
- add envVars with REDIS_URL linking to Render Redis service

## Testing
- `pytest` *(fails: coverage 52.78% < 80% required)*

------
https://chatgpt.com/codex/tasks/task_e_6899002b85d08320a06e8bcc25fac4e2