### PR TITLE
Reconnect Redis in health check for /health endpoint

### DIFF
--- a/app/api/v1/routers/health.py
+++ b/app/api/v1/routers/health.py
@@ -19,6 +19,8 @@ async def check_db(timeout: float = 1.0) -> bool:
 
 async def check_redis(timeout: float = 1.0) -> bool:
     if not cache.redis_client:
+        await cache._connect()
+    if not cache.redis_client:
         return False
     try:
         return await asyncio.wait_for(cache.redis_client.ping(), timeout)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from app.api.v1.routers import health
+
+
+class DummyRedis:
+    async def ping(self):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_check_redis_connects_when_client_missing(monkeypatch):
+    cache = health.cache
+    cache.redis_client = None
+
+    async def connect():
+        cache.redis_client = DummyRedis()
+
+    monkeypatch.setattr(cache, "_connect", AsyncMock(side_effect=connect))
+
+    assert await health.check_redis() is True
+    cache._connect.assert_awaited_once()
+
+    cache.redis_client = None


### PR DESCRIPTION
## Summary
- ensure `check_redis` establishes a Redis connection if the client is missing before pinging
- add unit test covering the reconnect logic of the Redis health check

## Testing
- `pytest` *(fails: Required test coverage of 80% not reached; FAILED tests/unit/test_openai_client.py::test_consulta_gpt - AssertionError: assert <coroutine object consulta_gpt at ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b688a2dbc83208fb7e4def8f427ff