### PR TITLE
feat: switch to responses API for web search

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -30,12 +30,13 @@ async def consulta_gpt(prompt: str) -> str:
         return "OPENAI_API_KEY no configurada. No se pudo realizar la consulta."
 
     try:
-        response = await client.chat.completions.create(
+        response = await client.responses.create(
             model="gpt-4o",
-            messages=[{"role": "user", "content": prompt}],
+            input=prompt,
             temperature=0.7,
+            connectors=[{"id": "web-search"}],
         )
-        return response.choices[0].message.content.strip()
+        return response.output_text.strip()
     except AuthenticationError as exc:
         logger.error("Error de autenticación con OpenAI: %s", exc)
         return "Error de autenticación con OpenAI."
@@ -45,3 +46,6 @@ async def consulta_gpt(prompt: str) -> str:
     except OpenAIError as exc:
         logger.error("Error de OpenAI: %s", exc)
         return "Ocurrió un error al consultar el modelo."
+    except Exception as exc:
+        logger.error("Error al realizar la búsqueda web: %s", exc)
+        return "La búsqueda web falló o devolvió un formato inesperado."

--- a/tests/unit/test_openai_client.py
+++ b/tests/unit/test_openai_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import types
 
@@ -6,23 +7,75 @@ import openai_client  # noqa: E402
 
 
 def test_consulta_gpt(monkeypatch):
-    class DummyChoice:
-        def __init__(self, content: str):
-            self.message = types.SimpleNamespace(content=content)
-
     class DummyResponse:
-        choices = [DummyChoice("Hola Mundo ")]
+        output_text = "Hola Mundo "
 
-    def fake_create(**kwargs):
+    async def fake_create(**kwargs):
         return DummyResponse()
 
     dummy_client = types.SimpleNamespace(
-        chat=types.SimpleNamespace(
-            completions=types.SimpleNamespace(create=fake_create)
-        )
+        responses=types.SimpleNamespace(create=fake_create)
     )
 
     monkeypatch.setattr(openai_client, "client", dummy_client)
 
-    result = openai_client.consulta_gpt("Hola?")
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
     assert result == "Hola Mundo"
+
+
+def test_consulta_gpt_sin_clave(monkeypatch):
+    monkeypatch.setattr(openai_client, "client", None)
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
+    assert "no configurada" in result.lower()
+
+
+def test_consulta_gpt_auth_error(monkeypatch):
+    class DummyAuthError(openai_client.AuthenticationError):
+        def __init__(self):
+            pass
+
+    async def fake_create(**kwargs):
+        raise DummyAuthError()
+
+    dummy_client = types.SimpleNamespace(
+        responses=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
+    assert "autenticaci" in result.lower()
+
+
+def test_consulta_gpt_timeout(monkeypatch):
+    async def fake_create(**kwargs):
+        raise asyncio.TimeoutError()
+
+    dummy_client = types.SimpleNamespace(
+        responses=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
+    assert "tiempo de espera" in result.lower()
+
+
+def test_consulta_gpt_openai_error(monkeypatch):
+    async def fake_create(**kwargs):
+        raise openai_client.OpenAIError("boom")
+
+    dummy_client = types.SimpleNamespace(
+        responses=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
+    assert "error al consultar" in result.lower()
+
+
+def test_consulta_gpt_generic_error(monkeypatch):
+    async def fake_create(**kwargs):
+        raise ValueError("fail")
+
+    dummy_client = types.SimpleNamespace(
+        responses=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(openai_client, "client", dummy_client)
+    result = asyncio.run(openai_client.consulta_gpt("Hola?"))
+    assert "búsqueda web" in result.lower()


### PR DESCRIPTION
## Summary
- use `client.responses.create` with web-search connector
- handle network and format errors gracefully
- expand tests for new responses API and error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b9aceb45c8320b2d313650c1b591e